### PR TITLE
Use rpm instead of pip for installation of system-wide Python packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ command as user who connects to the server.
 |                                    |          | enabled on RHEL machines for the `EPEL    |           |                                   |
 |                                    |          | repository`_.                             |           | ``- rhel-7-server-extras-rpms``   |
 +------------------------------------+----------+-------------------------------------------+-----------+-----------------------------------+
+| ``common_python3_enabled``         |  boolean | Install Python 3 if ``true``.             |     no    |             ``false``             |
++------------------------------------+----------+-------------------------------------------+-----------+-----------------------------------+
 | ``common_selinux_permisive``       |  boolean | Set SELinux to permisive mode if ``true``.|     no    |             ``false``             |
 +------------------------------------+----------+-------------------------------------------+-----------+-----------------------------------+
 | ``common_ssh_allowed_ips``         |   list   | List of ip addresses from which firewall  |     no    |              ``[]``               |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ common_rhel_repos_for_epel:
   - rhel-7-server-optional-rpms
   - rhel-7-server-extras-rpms
 
+common_python3_enabled: false
+
 common_selinux_permisive: false
 
 common_ssh_allowed_ips: []

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -8,3 +8,31 @@
     # terminal and requires far less dependencies than the python-ipython
     # package which provides the full IPython.
     - python-ipython-console
+
+- block:
+  - name: Install Python 3.4
+    package: name=python34 state=present
+
+  # NOTE: The following three steps are a work-around to allow creation of
+  # virtual environments with Python 3.4 until this is properly solved
+  # upstream. For more info, see:
+  # - https://bugzilla.redhat.com/show_bug.cgi?id=1263057
+  # - https://bugzilla.redhat.com/show_bug.cgi?id=1319963
+  # - https://bugzilla.redhat.com/show_bug.cgi?id=1411685
+  - name: Install setuptools
+    package: name=python-setuptools state=present
+
+  - name: Get virtualenv version
+    command: virtualenv --version
+    register: common_virtualenv_version_res
+    changed_when: false
+
+  # NOTE: This task installs a new virtualenv in the system-wide location and
+  # replaces the virtualenv executable from the python-virtualenv package.
+  # NOTE: easy_install module lacks proper change detection so we need to
+  # implement it ourselves.
+  - name: Update virtualenv with easy_install
+    easy_install: name=virtualenv state=latest
+    when: common_virtualenv_version_res.stdout | version_compare('15.1', '<')
+
+  when: common_python3_enabled

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -1,16 +1,10 @@
 ---
 
-- name: Install pip
-  package: name=python-devel state=present
-
-- name: Install pip
-  yum: name=python-pip state=present
-
-- name: Update pip
-  pip: name=pip state=latest
-
-- name: Install virtualenv
-  pip: name=virtualenv state=present
-
-- name: Install IPython
-  pip: name=ipython state=latest
+- name: Install Python utilities
+  package: name={{ item }} state=present
+  with_items:
+    - python-virtualenv
+    # NOTE: python-ipython-console package provides IPython for running in a
+    # terminal and requires far less dependencies than the python-ipython
+    # package which provides the full IPython.
+    - python-ipython-console


### PR DESCRIPTION
This prevents conflicts between `rpm` and `pip` (e.g. rpm complaining when updating `python-virtualenv` since all files have been modified with `pip`'s system-wide installation of `virtualenv`).
Drop installation of `python-devel` since it is not really a common requirement. Projects needing to build C extensions of Python packages should ensure it is installed separately.
Drop installation of `python-pip` to prevent users/administrators from thinking they can install system-wide Python packages with `pip`.