### PR TITLE
Enable fail2ban SSH jail

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -19,6 +19,14 @@
 - name: Install fail2ban
   package: name=fail2ban state=present
 
+- name: Enable fail2ban SSH jail
+  copy:
+    content: |
+      [sshd]
+      enabled = true
+    dest: /etc/fail2ban/jail.d/01-sshd.conf
+    mode: 0644
+
 - name: Ensure fail2ban is enabled and started
   service: name=fail2ban enabled=yes state=started
 


### PR DESCRIPTION
Fail2ban is currently just started, but has no enabled jails.  This commit enables the `sshd` jail to make this Ansible role more useful without any further customizations.