### PR TITLE
Remove work-around for creation of virtualenvs under Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,11 @@ Requirements
 Currently, the role only supports `CentOS`_ and
 `Red Hat Enterprise Linux (RHEL)`_ EL7 distribution flavors.
 
+It also requires RHEL/CentOS 7.4 or higher since it provides a newer
+python-virtualenv package (1.10.1-4.el7+) which fixes compatibility with
+Python 3 (for more details,
+see: https://bugzilla.redhat.com/show_bug.cgi?id=1411685).
+
 If you need support for other flavors, feel free to `submit a pull request`_.
 
 .. _CentOS: https://www.centos.org/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
-- name: Check that the system has CentOS 7 or RHEL 7 installed
+- name: Check that the system has CentOS 7.4+ or RHEL 7.4+ installed
   assert:
     that:
       - ansible_distribution in ["CentOS", "RedHat"]
-      - ansible_distribution_major_version | int == 7
+      - ansible_distribution_version | version_compare('7.4', '>=')
 
 - name: Get remote username
   become: false

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -9,30 +9,6 @@
     # package which provides the full IPython.
     - python-ipython-console
 
-- block:
-  - name: Install Python 3.4
-    package: name=python34 state=present
-
-  # NOTE: The following three steps are a work-around to allow creation of
-  # virtual environments with Python 3.4 until this is properly solved
-  # upstream. For more info, see:
-  # - https://bugzilla.redhat.com/show_bug.cgi?id=1263057
-  # - https://bugzilla.redhat.com/show_bug.cgi?id=1319963
-  # - https://bugzilla.redhat.com/show_bug.cgi?id=1411685
-  - name: Install setuptools
-    package: name=python-setuptools state=present
-
-  - name: Get virtualenv version
-    command: virtualenv --version
-    register: common_virtualenv_version_res
-    changed_when: false
-
-  # NOTE: This task installs a new virtualenv in the system-wide location and
-  # replaces the virtualenv executable from the python-virtualenv package.
-  # NOTE: easy_install module lacks proper change detection so we need to
-  # implement it ourselves.
-  - name: Update virtualenv with easy_install
-    easy_install: name=virtualenv state=latest
-    when: common_virtualenv_version_res.stdout | version_compare('15.1', '<')
-
+- name: Install Python 3.4
+  package: name=python34 state=present
   when: common_python3_enabled


### PR DESCRIPTION
Require RHEL/CentOS 7.4+ which provides a newer python-virtualenv package that fixes this.